### PR TITLE
Check Cluster on Retry from wait

### DIFF
--- a/app/invokeEMR.sh
+++ b/app/invokeEMR.sh
@@ -227,12 +227,13 @@ if [ $NEXTPHASE -eq 1 ]; then
         do
                 #double check that cluster isn't really up with one more check
                 aws emr list-clusters --active --region ${REGION} | grep -q ${CLUSTER_NAME}
+                STATUS=$?
 
                 if [ $STATUS -eq 0 ]; then
                         # We already have a cluster running - bail
                         logMsg "Cluster ERROR: existing cluster ${CLUSTER_NAME} running"
                         CLUSTERUP=1
-                        #set current attemps greated than while condition
+                        #set current attemps greater than while condition
                         CURR_ATTEMPT=$[$RETRIES+1]
                 else
                         logMsg "No existing EMR cluster with  name ${CLUSTER_NAME} running.  Creating"


### PR DESCRIPTION
There was an issue when running the aws emr wait cluster-running cli command where this command timed out after 30 minutes but on subsequent retry it created a duplicate EMR cluster. The cluster was already created since the create command was successful.  It had also started up but could not be evaluated by the wait command in time.

The old loop for retries did not actually double check that the cluster was created before trying to create it again. This change adds a duplicate check for the cluster name before trying to create a new one to make sure that it was not successfully created and running.  This should help if the wait command times out in the future.