### PR TITLE
Cluster status after wait retry

### DIFF
--- a/app/invokeEMR.sh
+++ b/app/invokeEMR.sh
@@ -226,7 +226,7 @@ if [ $NEXTPHASE -eq 1 ]; then
         while [ $CURR_ATTEMPT -le $RETRIES ]
         do
                 #double check that cluster isn't really running with one more check
-                aws emr list-clusters --cluster-states "RUNNING" --region ${REGION} | grep -q ${CLUSTER_NAME}
+                aws emr list-clusters --cluster-states STARTING BOOTSTRAPPING RUNNING WAITING --region ${REGION} | grep -q ${CLUSTER_NAME}
                 STATUS=$?
 
                 if [ $STATUS -eq 0 ]; then

--- a/app/invokeEMR.sh
+++ b/app/invokeEMR.sh
@@ -16,7 +16,7 @@ IMPORT_REGION=$7
 SPIKED_THROUGHPUT=$8
 
 WRITE_TPUT=0.8		# Used when we generate the Import steps
-RETRY_DELAY=10
+RETRY_DELAY=60
 
 # Just vars
 INSTALL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -225,8 +225,8 @@ if [ $NEXTPHASE -eq 1 ]; then
 
         while [ $CURR_ATTEMPT -le $RETRIES ]
         do
-                #double check that cluster isn't really up with one more check
-                aws emr list-clusters --active --region ${REGION} | grep -q ${CLUSTER_NAME}
+                #double check that cluster isn't really running with one more check
+                aws emr list-clusters --cluster-states "RUNNING" --region ${REGION} | grep -q ${CLUSTER_NAME}
                 STATUS=$?
 
                 if [ $STATUS -eq 0 ]; then


### PR DESCRIPTION
This change looks for active clusters with the "aws emr list-clusters" command meaning STARTING, BOOTSTRAPPING, RUNNING, and WAITING, using the --cluster-states option.  This excludes TERMINATING as an "active" cluster as per the normal "--active" switch.  This should solve issues where bootstrapping failed and the cluster is coming down but you don't want to consider that cluster as active and actually create a new cluster on retry.  Should still handle the issue where "aws emr wait cluster-running" times out.