### PR TITLE
Update EMR version from 5.8.0 to 5.20.0

### DIFF
--- a/app/invokeEMR.sh
+++ b/app/invokeEMR.sh
@@ -243,7 +243,7 @@ if [ $NEXTPHASE -eq 1 ]; then
                         logMsg "Creating new EMR Cluster NAME:${CLUSTER_NAME} Attempt ${CURR_ATTEMPT} of ${RETRIES}"
 
                         CLUSTERID=$(aws emr create-cluster --name "${CLUSTER_NAME}"                                        \
-                                    --release-label "emr-5.8.0"                                                            \
+                                    --release-label "emr-5.20.0"                                                           \
                                     --service-role "EMR_DefaultRole"                                                       \
                                     --security-configuration "dynamodb-backups"                                            \
                                     --tags Name=${CLUSTER_NAME} signiant:product=devops signiant:email=devops@signiant.com \

--- a/app/produce-steps-json.py
+++ b/app/produce-steps-json.py
@@ -168,6 +168,8 @@ def main(region,filter,destination,impregion,writetput,readtput, spikedread, s3l
           if spikedread is not None:
             tputSpikeStep = generateThroughputUpdateStep(table['name'], "Spike", s3ScriptPath, autoscale_min_spike_read_capacity, autoscale_min_spike_read_capacity, table['write'], region)
             exportSteps.append(tputSpikeStep)
+        else:
+          myLog("Table uses on-demand capacity - no need for spike and reset throughput steps")
 
         tableExportStep = generateTableExportStep(table['name'],tableS3Path,readtput,region)
         exportSteps.append(tableExportStep)

--- a/app/produce-steps-json.py
+++ b/app/produce-steps-json.py
@@ -101,7 +101,7 @@ def myLog(message):
 
   syslogMsg = procName + ": " + message
   syslog.syslog(syslogMsg)
-  print '%s %s' % (dateTimeStr,message)
+  print ('%s %s' % (dateTimeStr,message))
 
 def main(region,filter,destination,impregion,writetput,readtput, spikedread, s3location,appname,excludes):
 
@@ -154,24 +154,28 @@ def main(region,filter,destination,impregion,writetput,readtput, spikedread, s3l
         autoscale_min_reset_read_capacity = None
         tableS3Path = s3ExportPath + "/" + table['name']
 
-        # Does this table have autoscaling enabled?
-        scalable_target_info = scalable_target_exists(region,"table/" + table['name'],"dynamodb:table:ReadCapacityUnits")
-        if scalable_target_info is not None:
+        # Check if table is set to On Demand Capacity
+        if int(table['read']) > 0:
+          myLog("Table uses provisioned capacity - need to add throughput spike and reset steps")
+          # Does this table have autoscaling enabled?
+          scalable_target_info = scalable_target_exists(region,"table/" + table['name'],"dynamodb:table:ReadCapacityUnits")
+          if scalable_target_info is not None:
             myLog("Table " + table['name'] + " has autoscaling enabled")
-            autoscale_min_spike_read_capacity = spikedread
-            autoscale_min_reset_read_capacity=scalable_target_info[0]['MinCapacity']
+            autoscale_min_spike_read_capacity = scalable_target_info[0]['MinCapacity'] + int(spikedread)
+            autoscale_min_reset_read_capacity = scalable_target_info[0]['MinCapacity']
             myLog("Table " + table['name'] + " has a current AS min capacity of " + str(autoscale_min_reset_read_capacity))
 
-        if spikedread is not None:
-            tputSpikeStep = generateThroughputUpdateStep(table['name'], "Spike", s3ScriptPath, spikedread, autoscale_min_spike_read_capacity, table['write'], region)
+          if spikedread is not None:
+            tputSpikeStep = generateThroughputUpdateStep(table['name'], "Spike", s3ScriptPath, autoscale_min_spike_read_capacity, autoscale_min_spike_read_capacity, table['write'], region)
             exportSteps.append(tputSpikeStep)
 
         tableExportStep = generateTableExportStep(table['name'],tableS3Path,readtput,region)
         exportSteps.append(tableExportStep)
 
-        if spikedread is not None:
-            tputResetStep = generateThroughputUpdateStep(table['name'], "Reset", s3ScriptPath, table['read'], autoscale_min_reset_read_capacity, table['write'], region)
-            exportSteps.append(tputResetStep)
+        if int(table['read']) > 0:
+            if spikedread is not None:
+                tputResetStep = generateThroughputUpdateStep(table['name'], "Reset", s3ScriptPath, table['read'], autoscale_min_reset_read_capacity, table['write'], region)
+                exportSteps.append(tputResetStep)
 
         tableImportStep = generateTableImportStep(table['name'],tableS3Path,writetput,impregion)
         importSteps.append(tableImportStep)
@@ -189,7 +193,7 @@ def main(region,filter,destination,impregion,writetput,readtput, spikedread, s3l
 ## Add a JSON entry for a single table throughput update step
 ###########
 def generateThroughputUpdateStep(tableName, stepName, s3Path, readtput, autoscale_min_throughput,writetput, region):
-    myLog("addThroughputUpdateStep %s" % tableName)
+    myLog("addThroughputUpdateStep (%s) %s" % (stepName, tableName))
 
     tputUpdateDict = {}
 
@@ -201,8 +205,8 @@ def generateThroughputUpdateStep(tableName, stepName, s3Path, readtput, autoscal
                             "Args": [s3Path,
                                 region,
                                 tableName,
-                                readtput,
-                                writetput,
+                                str(readtput),
+                                str(writetput),
                                 str(autoscale_min_throughput)
                                 ]
                         }
@@ -214,8 +218,8 @@ def generateThroughputUpdateStep(tableName, stepName, s3Path, readtput, autoscal
                             "Args": [s3Path,
                                 region,
                                 tableName,
-                                readtput,
-                                writetput
+                                str(readtput),
+                                str(writetput)
                                 ]
                         }
 
@@ -334,7 +338,7 @@ def scalable_target_exists(region,resource_id,scalable_dimension):
             ],
             ScalableDimension=scalable_dimension
         )
-    except Exception, e:
+    except Exception as e:
         myLog("Failed to describe scalable targets " + str(e))
 
     if response:

--- a/app/update-throughput.sh
+++ b/app/update-throughput.sh
@@ -130,7 +130,7 @@ echo "Updating the base table read throughput with update-table to ${READ_CAPACI
 if [ ${RET_CODE} -eq 0 ]; then
   # Update the table throughput directly
   # This is needed in case there is no autoscaling enabled OR
-  # if autoscaling is enabled and there is no read acitivty on the table
+  # if autoscaling is enabled and there is no read activity on the table
   # Since autoscaling will never scale back down by itself
   TABLE_STATUS=$(aws dynamodb update-table \
                     --region $SOURCE_REGION \


### PR DESCRIPTION
- better handle throughput spike/reset
- add support for on-demand provisioned tables (even though the version of the DynamoDbExport class from the emr-ddb.jar referenced in this repo doesn't support it)
-- I will be creating a separate branch that will reference a new jar (SNAPSHOT built locally) that *does* have support for on-demand tables